### PR TITLE
Add admin authorization system to new users

### DIFF
--- a/nativeauthenticator/orm.py
+++ b/nativeauthenticator/orm.py
@@ -2,7 +2,7 @@ import bcrypt
 from jupyterhub.orm import Base, User
 
 from sqlalchemy import (
-    Column, ForeignKey, Integer, String
+    Boolean, Column, ForeignKey, Integer, String
 )
 from sqlalchemy.orm import relationship
 
@@ -12,16 +12,25 @@ class UserInfo(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     username = Column(String, nullable=False)
     password = Column(String, nullable=False)
+    is_authorized = Column(Boolean, default=False)
     user_id = Column(Integer, ForeignKey('users.id'))
     user = relationship(User)
 
     @classmethod
     def find(cls, db, username):
         """Find a user info record by name.
-        Returns None if not found.
-        """
+        Returns None if not found"""
         return db.query(cls).filter(cls.username == username).first()
 
     def is_valid_password(self, password):
+        """Checks if a password passed matches the
+        password stored"""
         encoded_pw = bcrypt.hashpw(password.encode(), self.password)
         return encoded_pw == self.password
+
+    @classmethod
+    def change_authorization(cls, db, username):
+        user = db.query(cls).filter(cls.username == username).first()
+        user.is_authorized = not user.is_authorized
+        db.commit()
+        return user

--- a/nativeauthenticator/tests/test_authenticator.py
+++ b/nativeauthenticator/tests/test_authenticator.py
@@ -65,3 +65,4 @@ async def test_handlers(app):
     auth = NativeAuthenticator(db=app.db)
     handlers = auth.get_handlers(app)
     assert handlers[1][0] == '/signup'
+    assert handlers[2][0] == '/authorize'

--- a/nativeauthenticator/tests/test_authenticator.py
+++ b/nativeauthenticator/tests/test_authenticator.py
@@ -51,10 +51,20 @@ async def test_failed_authentication_wrong_password(tmpcwd, app):
     assert not response
 
 
+async def test_failed_authentication_not_authorized(tmpcwd, app):
+    '''Test if authentication fails with a wrong password'''
+    auth = NativeAuthenticator(db=app.db)
+    auth.get_or_create_user('John Snow', 'password')
+    response = await auth.authenticate(app, {'username': 'John Snow',
+                                             'password': 'password'})
+    assert not response
+
+
 async def test_succeded_authentication(tmpcwd, app):
     '''Test a successfull authentication'''
     auth = NativeAuthenticator(db=app.db)
     user = auth.get_or_create_user('John Snow', 'password')
+    UserInfo.change_authorization(app.db, 'John Snow')
     response = await auth.authenticate(app, {'username': 'John Snow',
                                              'password': 'password'})
     assert response == user.name


### PR DESCRIPTION
This pull request closes all tasks on #19 and #20 

- [X] Create a new endpoint for admin 
- [X] Verify admin privileges to access new endpoint
- [X] Add list of users on the system
- [X] Allow to authorize users that had signed up to enter the system
- [X] Make users created by signup unable to access the system until admin authorization
- [X] Verify authorization of admin when users try to authenticate to the system
- [X] Admin users defined on the config file should be created in SignUp but they are already authorized to enter the system

The Authorization area looks like this:

<img width="1440" alt="screen shot 2019-01-14 at 16 45 53" src="https://user-images.githubusercontent.com/7255297/51127230-edd7bb00-181c-11e9-928b-6db77d4bfcb3.png">
