### PR TITLE
Add all info from signup post to get_or_create_user

### DIFF
--- a/nativeauthenticator/handlers.py
+++ b/nativeauthenticator/handlers.py
@@ -2,6 +2,7 @@ import os
 from jinja2 import ChoiceLoader, FileSystemLoader
 from jupyterhub.handlers import BaseHandler
 from jupyterhub.utils import admin_only
+from urllib import parse
 
 from tornado import web
 
@@ -61,9 +62,9 @@ class SignUpHandler(LocalBase):
         return alert, message
 
     async def post(self):
-        username = self.get_body_argument('username', strip=False)
-        password = self.get_body_argument('password', strip=False)
-        user = self.authenticator.get_or_create_user(username, password)
+        body = self.request.body.decode('utf-8')
+        body_arguments = dict(parse.parse_qsl(body))
+        user = self.authenticator.get_or_create_user(**body_arguments)
 
         alert, message = self.get_result_message(user)
 

--- a/nativeauthenticator/handlers.py
+++ b/nativeauthenticator/handlers.py
@@ -2,7 +2,6 @@ import os
 from jinja2 import ChoiceLoader, FileSystemLoader
 from jupyterhub.handlers import BaseHandler
 from jupyterhub.utils import admin_only
-from urllib import parse
 
 from tornado import web
 
@@ -62,9 +61,12 @@ class SignUpHandler(LocalBase):
         return alert, message
 
     async def post(self):
-        body = self.request.body.decode('utf-8')
-        body_arguments = dict(parse.parse_qsl(body))
-        user = self.authenticator.get_or_create_user(**body_arguments)
+        user_info = {
+            'username': self.get_body_argument('username', strip=False),
+            'pw': self.get_body_argument('pw', strip=False),
+            'email': self.get_body_argument('email', '', strip=False),
+        }
+        user = self.authenticator.get_or_create_user(**user_info)
 
         alert, message = self.get_result_message(user)
 

--- a/nativeauthenticator/nativeauthenticator.py
+++ b/nativeauthenticator/nativeauthenticator.py
@@ -149,12 +149,14 @@ class NativeAuthenticator(Authenticator):
         if username in self.admin_users or self.open_signup:
             infos.update({'is_authorized': True})
 
-        user_info = UserInfo(**infos)
-        user = User(name=username)
+        try:
+            user_info = UserInfo(**infos)
+            user = User(name=username)
+        except AssertionError:
+            return
 
         self.db.add_all([user_info, user])
         self.db.commit()
-
         return user_info
 
     def change_password(self, username, new_password):

--- a/nativeauthenticator/templates/signup.html
+++ b/nativeauthenticator/templates/signup.html
@@ -49,7 +49,7 @@ document.addEventListener('DOMContentLoaded', function() {
             <input
             type="password"
             class="form-control"
-            name="password"
+            name="pw"
             id="pwd"
             tabindex="2"
             required


### PR DESCRIPTION
When creating a new user with email, the handler was not passing this information to the function `get_or_create_user` and the email was not being stored. This fixes this problem