### PR TITLE
fix password is not bytes in mysql

### DIFF
--- a/nativeauthenticator/orm.py
+++ b/nativeauthenticator/orm.py
@@ -23,8 +23,9 @@ class UserInfo(Base):
     def is_valid_password(self, password):
         """Checks if a password passed matches the
         password stored"""
-        encoded_pw = bcrypt.hashpw(password.encode(), self.password)
-        return encoded_pw == self.password
+        check_pwd = self.password.encode() if type(self.password) != bytes else self.password
+        encoded_pw = bcrypt.hashpw(password.encode(), check_pwd)
+        return encoded_pw == check_pwd
 
     @classmethod
     def change_authorization(cls, db, username):

--- a/nativeauthenticator/orm.py
+++ b/nativeauthenticator/orm.py
@@ -2,7 +2,7 @@ import bcrypt
 import re
 from jupyterhub.orm import Base
 
-from sqlalchemy import Boolean, Column, Integer, String
+from sqlalchemy import Boolean, Column, Integer, String, LargeBinary
 from sqlalchemy.orm import validates
 
 
@@ -10,7 +10,7 @@ class UserInfo(Base):
     __tablename__ = 'users_info'
     id = Column(Integer, primary_key=True, autoincrement=True)
     username = Column(String, nullable=False)
-    password = Column(String, nullable=False)
+    password = Column(LargeBinary, nullable=False)
     is_authorized = Column(Boolean, default=False)
     email = Column(String)
 
@@ -23,9 +23,8 @@ class UserInfo(Base):
     def is_valid_password(self, password):
         """Checks if a password passed matches the
         password stored"""
-        check_pwd = self.password.encode() if type(self.password) != bytes else self.password
-        encoded_pw = bcrypt.hashpw(password.encode(), check_pwd)
-        return encoded_pw == check_pwd
+        encoded_pw = bcrypt.hashpw(password.encode(), self.password)
+        return encoded_pw == self.password
 
     @classmethod
     def change_authorization(cls, db, username):

--- a/nativeauthenticator/tests/test_orm.py
+++ b/nativeauthenticator/tests/test_orm.py
@@ -1,5 +1,6 @@
 import pytest
 from jupyterhub.tests.mocking import MockHub
+from sqlalchemy.exc import StatementError
 
 from ..orm import UserInfo
 
@@ -19,10 +20,17 @@ def app():
 @pytest.mark.parametrize('email', ['john', 'john@john'])
 def test_validate_method_wrong_email(email, tmpdir, app):
     with pytest.raises(AssertionError):
-        UserInfo(username='john', password='pwd', email=email)
+        UserInfo(username='john', password=b'pwd', email=email)
 
 
 def test_validate_method_correct_email(tmpdir, app):
-    user = UserInfo(username='john', password='pwd', email='john@john.com')
+    user = UserInfo(username='john', password=b'pwd', email='john@john.com')
     app.db.add(user)
     assert UserInfo.find(app.db, 'john')
+
+
+def test_wrong_pwd_type(tmpdir, app):
+    with pytest.raises(StatementError):
+        user = UserInfo(username='john', password='pwd', email='john@john.com')
+        app.db.add(user)
+        UserInfo.find(app.db, 'john')


### PR DESCRIPTION
Hi @leportella . I use mysql database as backend.
The log:
```
 HTTPServerRequest(protocol='http', host='localhost:8000', method='POST', uri='/hub/login?next=', version='HTTP/1.1', remote_ip='::ffff:127.0.0.1')
    Traceback (most recent call last):
      File "/home/kai/work/embark3_env/venv/lib/python3.5/site-packages/tornado/web.py", line 1592, in _execute
        result = yield result
      File "/usr/lib/python3.5/asyncio/futures.py", line 274, in result
        raise self._exception
      File "/home/kai/work/embark3_env/venv/lib/python3.5/site-packages/jupyterhub/handlers/login.py", line 82, in post
        user = yield self.login_user(data)
      File "/usr/lib/python3.5/asyncio/futures.py", line 274, in result
        raise self._exception
      File "/home/kai/work/embark3_env/venv/lib/python3.5/site-packages/jupyterhub/handlers/base.py", line 327, in login_user
        authenticated = yield self.authenticate(data)
      File "/usr/lib/python3.5/asyncio/futures.py", line 274, in result
        raise self._exception
      File "/home/kai/work/embark3_env/venv/lib/python3.5/site-packages/jupyterhub/auth.py", line 221, in get_authenticated_user
        authenticated = yield self.authenticate(handler, data)
      File "/usr/lib/python3.5/asyncio/futures.py", line 274, in result
        raise self._exception
      File "/home/kai/work/embark3_env/venv/lib/python3.5/types.py", line 243, in wrapped
        coro = func(*args, **kwargs)
      File "/home/kai/work/embark3_env/nativeauthenticator/nativeauthenticator/nativeauthenticator.py", line 114, in authenticate
        if user.is_authorized and user.is_valid_password(password):
      File "/home/kai/work/embark3_env/nativeauthenticator/nativeauthenticator/orm.py", line 26, in is_valid_password
        encoded_pw = bcrypt.hashpw(password.encode(), self.password)
      File "/home/kai/work/embark3_env/venv/lib/python3.5/site-packages/bcrypt/__init__.py", line 61, in hashpw
        raise TypeError("Unicode-objects must be encoded before hashing")
    TypeError: Unicode-objects must be encoded before hashing
```

The issue is that mysql can not save password as bytes although the return of `bcrypt.hashpw` is bytes in `nativeauthenticator.py`
```
encoded_pw = bcrypt.hashpw(pw.encode(), bcrypt.gensalt())
infos = {'username': username, 'password': encoded_pw}
infos.update(kwargs)
```

