### PR TITLE
fix raise error when email is none

### DIFF
--- a/nativeauthenticator/orm.py
+++ b/nativeauthenticator/orm.py
@@ -35,6 +35,8 @@ class UserInfo(Base):
 
     @validates('email')
     def validate_email(self, key, address):
+        if not address:
+            return
         assert re.match(r"^[A-Za-z0-9\.\+_-]+@[A-Za-z0-9\._-]+\.[a-zA-Z]*$",
                         address)
         return address


### PR DESCRIPTION
Hi @leportella 
When I want to sign up a new user, it just show `Something went wrong. Be sure your password doesn't have spaces or commas and is not too common.`. Then, I just add a traceback and shows like:
```
 Traceback (most recent call last):
  File "/home/kai/work/embark3_env/nativeauthenticator/nativeauthenticator/nativeauthenticator.py", line 156, in get_or_create_user
    user_info = UserInfo(**infos)
  File "<string>", line 4, in __init__
  File "/home/kai/work/embark3_env/venv/lib/python3.5/site-packages/sqlalchemy/orm/state.py", line 424, in _initialize_instance
    manager.dispatch.init_failure(self, args, kwargs)
  File "/home/kai/work/embark3_env/venv/lib/python3.5/site-packages/sqlalchemy/util/langhelpers.py", line 66, in __exit__
    compat.reraise(exc_type, exc_value, exc_tb)
  File "/home/kai/work/embark3_env/venv/lib/python3.5/site-packages/sqlalchemy/util/compat.py", line 249, in reraise
    raise value
  File "/home/kai/work/embark3_env/venv/lib/python3.5/site-packages/sqlalchemy/orm/state.py", line 421, in _initialize_instance
    return manager.original_init(*mixed[1:], **kwargs)
  File "/home/kai/work/embark3_env/venv/lib/python3.5/site-packages/sqlalchemy/ext/declarative/base.py", line 748, in _declarative_constructor
    setattr(self, k, kwargs[k])
  File "/home/kai/work/embark3_env/venv/lib/python3.5/site-packages/sqlalchemy/orm/attributes.py", line 229, in __set__
    instance_dict(instance), value, None)
  File "/home/kai/work/embark3_env/venv/lib/python3.5/site-packages/sqlalchemy/orm/attributes.py", line 710, in set
    value, old, initiator)
  File "/home/kai/work/embark3_env/venv/lib/python3.5/site-packages/sqlalchemy/orm/attributes.py", line 717, in fire_replace_event
    state, value, previous, initiator or self._replace_token)
  File "/home/kai/work/embark3_env/venv/lib/python3.5/site-packages/sqlalchemy/orm/util.py", line 136, in set_
    return validator(state.obj(), key, value)
  File "/home/kai/work/embark3_env/nativeauthenticator/nativeauthenticator/orm.py", line 40, in validate_email
    address)
AssertionError
```
So I think it maybe empty emaill error, then I add a empty return and everything is ok.