### PR TITLE
Remove duplication creation of user

### DIFF
--- a/nativeauthenticator/nativeauthenticator.py
+++ b/nativeauthenticator/nativeauthenticator.py
@@ -2,7 +2,6 @@ import bcrypt
 import os
 from datetime import datetime
 from jupyterhub.auth import Authenticator
-from jupyterhub.orm import User
 
 from sqlalchemy import inspect
 from tornado import gen
@@ -151,11 +150,10 @@ class NativeAuthenticator(Authenticator):
 
         try:
             user_info = UserInfo(**infos)
-            user = User(name=username)
         except AssertionError:
             return
 
-        self.db.add_all([user_info, user])
+        self.db.add(user_info)
         self.db.commit()
         return user_info
 

--- a/nativeauthenticator/tests/test_authenticator.py
+++ b/nativeauthenticator/tests/test_authenticator.py
@@ -1,6 +1,5 @@
 import pytest
 import time
-from jupyterhub.orm import User
 from jupyterhub.tests.mocking import MockHub
 
 from nativeauthenticator import NativeAuthenticator
@@ -42,9 +41,7 @@ async def test_create_user(is_admin, open_signup, expected_authorization,
 
     auth.get_or_create_user('johnsnow', 'password')
     user_info = UserInfo.find(app.db, 'johnsnow')
-    user = User.find(app.db, 'johnsnow')
     assert user_info.username == 'johnsnow'
-    assert user.name == 'johnsnow'
     assert user_info.is_authorized == expected_authorization
 
 
@@ -163,7 +160,7 @@ async def test_delete_user(tmpcwd, app):
     auth = NativeAuthenticator(db=app.db)
     auth.get_or_create_user('johnsnow', 'password')
 
-    user = User.find(app.db, 'johnsnow')
+    user = type('User', (), {'name': 'johnsnow'})
     auth.delete_user(user)
 
     user_info = UserInfo.find(app.db, 'johnsnow')


### PR DESCRIPTION
Some pull requests ago, I added the creation of a User when UserInfo was created on SignUp.

However, this behavior is returning problems because Users are already created when a user login. So, the duplication was returning an error, specially for admins that have their users created previously.