### PR TITLE
postgres says `opt_secret` is too long for `varying(10)`

### DIFF
--- a/nativeauthenticator/orm.py
+++ b/nativeauthenticator/orm.py
@@ -17,7 +17,7 @@ class UserInfo(Base):
     is_authorized = Column(Boolean, default=False)
     email = Column(String)
     has_2fa = Column(Boolean, default=False)
-    otp_secret = Column(String(10))
+    otp_secret = Column(String(16))
 
     def __init__(self, **kwargs):
         super(UserInfo, self).__init__(**kwargs)


### PR DESCRIPTION
`otp_secret` should be `varying(16)` since `base64.b32encode(os.urandom(10)).decode('utf-8')` produces a string of length 16. sqlite3 didn't yell about this but postgres did.