### PR TITLE
Add check for None before trying to delete a user.

### DIFF
--- a/nativeauthenticator/nativeauthenticator.py
+++ b/nativeauthenticator/nativeauthenticator.py
@@ -214,8 +214,9 @@ class NativeAuthenticator(Authenticator):
 
     def delete_user(self, user):
         user_info = UserInfo.find(self.db, user.name)
-        self.db.delete(user_info)
-        self.db.commit()
+        if user_info is not None:
+            self.db.delete(user_info)
+            self.db.commit()
         return super().delete_user(user)
 
     def delete_dbm_db(self):


### PR DESCRIPTION
Users who were created via the Admin UI (/hub/admin -> Add Users) but never logged in are not in the db and trying to delete them in the Admin UI throws an exception.
![nativeauthenticator-exception](https://user-images.githubusercontent.com/3775781/62779528-c2b40200-bab3-11e9-8f9e-38222ec881e6.png)


