### PR TITLE
fix timedelta.seconds misuse

### DIFF
--- a/nativeauthenticator/nativeauthenticator.py
+++ b/nativeauthenticator/nativeauthenticator.py
@@ -104,7 +104,7 @@ class NativeAuthenticator(Authenticator):
             return True
 
         time_last_attempt = datetime.now() - login_attempts['time']
-        if time_last_attempt.seconds > self.seconds_before_next_try:
+        if time_last_attempt.total_seconds() > self.seconds_before_next_try:
             return True
 
         return False


### PR DESCRIPTION
`timedelta.seconds` is the number of seconds in the remaining day and is always < 86399. What you meant is `timedelta.total_seconds()`

See: https://stackoverflow.com/questions/51652952/python-timedelta-seconds-vs-total-seconds