### PR TITLE
Authenticator should accept passwords that are exactly the minimum length

### DIFF
--- a/nativeauthenticator/nativeauthenticator.py
+++ b/nativeauthenticator/nativeauthenticator.py
@@ -160,7 +160,7 @@ class NativeAuthenticator(Authenticator):
         return password in self.COMMON_PASSWORDS
 
     def is_password_strong(self, password):
-        checks = [len(password) > self.minimum_password_length]
+        checks = [len(password) >= self.minimum_password_length]
 
         if self.check_common_password:
             checks.append(not self.is_password_common(password))


### PR DESCRIPTION
Currently, the authenticator complains during signup if you enter a password that has exactly the minimum length and suggest you enter a password of at least the minimum length.

This could lead to confusion for the users. This pull request makes the authenticator also accept passwords that are the exact minimum length.