### PR TITLE
Make hardcoded urls relative to base_url

### DIFF
--- a/nativeauthenticator/handlers.py
+++ b/nativeauthenticator/handlers.py
@@ -37,6 +37,7 @@ class SignUpHandler(LocalBase):
             'signup.html',
             ask_email=self.authenticator.ask_email_on_signup,
             two_factor_auth=self.authenticator.allow_2fa,
+            base_url=self.base_url,
         )
         self.finish(html)
 
@@ -88,6 +89,7 @@ class SignUpHandler(LocalBase):
             two_factor_auth=self.authenticator.allow_2fa,
             two_factor_auth_user=user_2fa,
             two_factor_auth_value=otp_secret,
+            base_url=self.base_url,
         )
         self.finish(html)
 
@@ -101,6 +103,7 @@ class AuthorizationHandler(LocalBase):
             'autorization-area.html',
             ask_email=self.authenticator.ask_email_on_signup,
             users=self.db.query(UserInfo).all(),
+            base_url=self.base_url,
         )
         self.finish(html)
 
@@ -109,7 +112,7 @@ class ChangeAuthorizationHandler(LocalBase):
     @admin_only
     async def get(self, slug):
         UserInfo.change_authorization(self.db, slug)
-        self.redirect('/authorize')
+        self.redirect(self.base_url.rstrip('/') + '/authorize')
 
 
 class ChangePasswordHandler(LocalBase):
@@ -150,4 +153,5 @@ class LoginHandler(LoginHandler, LocalBase):
                 self.authenticator.login_url(self.hub.base_url),
                 {'next': self.get_argument('next', '')},
             ),
+            base_url=self.base_url,
         )

--- a/nativeauthenticator/handlers.py
+++ b/nativeauthenticator/handlers.py
@@ -112,7 +112,7 @@ class ChangeAuthorizationHandler(LocalBase):
     @admin_only
     async def get(self, slug):
         UserInfo.change_authorization(self.db, slug)
-        self.redirect(self.base_url.rstrip('/') + '/authorize')
+        self.redirect(self.base_url + '/authorize')
 
 
 class ChangePasswordHandler(LocalBase):

--- a/nativeauthenticator/templates/autorization-area.html
+++ b/nativeauthenticator/templates/autorization-area.html
@@ -24,7 +24,7 @@
                 <td>{{ user.has_2fa }}</td>
                 <td>Yes</td>
                 <td>
-                    <a class="btn btn-default" href="{{ base_url.rstrip("/") }}/hub/authorize/{{ user.username }}" role="button">Unauthorize</a>
+                    <a class="btn btn-default" href="{{ base_url }}hub/authorize/{{ user.username }}" role="button">Unauthorize</a>
                 </td>
                 {% else %}
             <tr>
@@ -35,7 +35,7 @@
                 <td>{{ user.has_2fa }}</td>
                 <td>No</td>
                 <td>
-                    <a class="btn btn-jupyter" href="{{ base_url.rstrip("/") }}/hub/authorize/{{ user.username }}" role="button">Authorize</a>
+                    <a class="btn btn-jupyter" href="{{ base_url }}hub/authorize/{{ user.username }}" role="button">Authorize</a>
                 </td>
                 {% endif %}
             </tr>

--- a/nativeauthenticator/templates/autorization-area.html
+++ b/nativeauthenticator/templates/autorization-area.html
@@ -24,7 +24,7 @@
                 <td>{{ user.has_2fa }}</td>
                 <td>Yes</td>
                 <td>
-                    <a class="btn btn-default" href="/hub/authorize/{{ user.username }}" role="button">Unauthorize</a>
+                    <a class="btn btn-default" href="{{ base_url.rstrip("/") }}/hub/authorize/{{ user.username }}" role="button">Unauthorize</a>
                 </td>
                 {% else %}
             <tr>
@@ -35,7 +35,7 @@
                 <td>{{ user.has_2fa }}</td>
                 <td>No</td>
                 <td>
-                    <a class="btn btn-jupyter" href="/hub/authorize/{{ user.username }}" role="button">Authorize</a>
+                    <a class="btn btn-jupyter" href="{{ base_url.rstrip("/") }}/hub/authorize/{{ user.username }}" role="button">Authorize</a>
                 </td>
                 {% endif %}
             </tr>

--- a/nativeauthenticator/templates/native-login.html
+++ b/nativeauthenticator/templates/native-login.html
@@ -50,7 +50,7 @@ document.addEventListener('DOMContentLoaded', function() {
             {% endif %}
             <input type="submit" id="login_submit" class='btn btn-jupyter' value='Sign In' tabindex="3" />
             <div style="padding-top: 25px;">
-                <p>Don't have an user? <a href="/signup">Signup!</a></p>
+                <p>Don't have an user? <a href="{{ base_url.rstrip("/") }}/signup">Signup!</a></p>
             </div>
         </div>
     </form>

--- a/nativeauthenticator/templates/native-login.html
+++ b/nativeauthenticator/templates/native-login.html
@@ -50,7 +50,7 @@ document.addEventListener('DOMContentLoaded', function() {
             {% endif %}
             <input type="submit" id="login_submit" class='btn btn-jupyter' value='Sign In' tabindex="3" />
             <div style="padding-top: 25px;">
-                <p>Don't have an user? <a href="{{ base_url.rstrip("/") }}/signup">Signup!</a></p>
+                <p>Don't have a user? <a href="{{ base_url.rstrip("/") }}/signup">Signup!</a></p>
             </div>
         </div>
     </form>

--- a/nativeauthenticator/templates/native-login.html
+++ b/nativeauthenticator/templates/native-login.html
@@ -50,7 +50,7 @@ document.addEventListener('DOMContentLoaded', function() {
             {% endif %}
             <input type="submit" id="login_submit" class='btn btn-jupyter' value='Sign In' tabindex="3" />
             <div style="padding-top: 25px;">
-                <p>Don't have a user? <a href="{{ base_url.rstrip("/") }}/signup">Signup!</a></p>
+                <p>Don't have a user? <a href="{{ base_url }}signup">Signup!</a></p>
             </div>
         </div>
     </form>

--- a/nativeauthenticator/templates/signup.html
+++ b/nativeauthenticator/templates/signup.html
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', function() {
             {% endif %}
             <input type="submit" id="signup_submit" class='btn btn-jupyter' value='Create User' tabindex="3" />
             <div style="padding-top: 25px;">
-                Already have a user? <a href="{{ base_url.rstrip("/") }}/login">Login!</a>
+                Already have a user? <a href="{{ base_url }}login">Login!</a>
             </div>
             {% if alert %}
             <div class="alert {{alert}}" style="margin-top: 15px;" role="alert">

--- a/nativeauthenticator/templates/signup.html
+++ b/nativeauthenticator/templates/signup.html
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', function() {
             {% endif %}
             <input type="submit" id="signup_submit" class='btn btn-jupyter' value='Create User' tabindex="3" />
             <div style="padding-top: 25px;">
-                Already have an user? <a href="{{ base_url.rstrip("/") }}/login">Login!</a>
+                Already have a user? <a href="{{ base_url.rstrip("/") }}/login">Login!</a>
             </div>
             {% if alert %}
             <div class="alert {{alert}}" style="margin-top: 15px;" role="alert">

--- a/nativeauthenticator/templates/signup.html
+++ b/nativeauthenticator/templates/signup.html
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', function() {
             {% endif %}
             <input type="submit" id="signup_submit" class='btn btn-jupyter' value='Create User' tabindex="3" />
             <div style="padding-top: 25px;">
-                Already have an user? <a href="/login">Login!</a>
+                Already have an user? <a href="{{ base_url.rstrip("/") }}/login">Login!</a>
             </div>
             {% if alert %}
             <div class="alert {{alert}}" style="margin-top: 15px;" role="alert">


### PR DESCRIPTION
Fixes #94 

Basically made all urls relative to the Hub's `base_url`. This value always ends in `"/"`.

I wasn't sure how to unit test this (the existing tests still pass), but I went through the flows of

* signing up
* authorizing a user
* logging in
* logging out
* de-authorizing a user

both with and without a `base_url` configured to verify the correct behaviour and redirection. This was done using the `jupyterhub/jupyterhub` Docker image and the [recommended configuration](https://github.com/jupyterhub/nativeauthenticator/blob/master/CONTRIBUTING.md#running-your-local-project).
