### PR TITLE
Add announcement_login handling to login template

### DIFF
--- a/nativeauthenticator/templates/native-login.html
+++ b/nativeauthenticator/templates/native-login.html
@@ -1,4 +1,7 @@
 {% extends "page.html" %}
+{% if announcement_login %}
+  {% set announcement = announcement_login %}
+{% endif %}
 {% block main %}
 <script type="text/javascript">
 document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
This PR handles the `announcement_login` template var in the same way as the [default login template](https://github.com/jupyterhub/jupyterhub/blob/master/share/jupyterhub/templates/login.html#L2-L4)