### PR TITLE
Add option for disable user to signup

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -45,6 +45,16 @@ You can also define the number of seconds a user must wait before trying again. 
 
 .. image:: _static/block_user_failed_logins.png
 
+Disable SignUp
+--------------
+
+By default Native Authenticator allows everyone to register user accounts. But you can add a option to disable signup. To do so, just add the following line to the config file:
+
+.. code-block:: python
+
+    c.Authenticator.enable_signup = False
+
+
 Open SignUp
 -----------
 

--- a/nativeauthenticator/handlers.py
+++ b/nativeauthenticator/handlers.py
@@ -32,6 +32,9 @@ class LocalBase(BaseHandler):
 class SignUpHandler(LocalBase):
     """Render the sign in page."""
     async def get(self):
+        if not self.authenticator.enable_signup:
+            raise web.HTTPError(404)
+
         self._register_template_path()
         html = self.render_template(
             'signup.html',
@@ -65,6 +68,9 @@ class SignUpHandler(LocalBase):
         return alert, message
 
     async def post(self):
+        if not self.authenticator.enable_signup:
+            raise web.HTTPError(404)
+
         user_info = {
             'username': self.get_body_argument('username', strip=False),
             'pw': self.get_body_argument('pw', strip=False),
@@ -145,6 +151,7 @@ class LoginHandler(LoginHandler, LocalBase):
             login_error=login_error,
             custom_html=self.authenticator.custom_html,
             login_url=self.settings['login_url'],
+            enable_signup=self.authenticator.enable_signup,
             two_factor_auth=self.authenticator.allow_2fa,
             authenticator_login_url=url_concat(
                 self.authenticator.login_url(self.hub.base_url),

--- a/nativeauthenticator/nativeauthenticator.py
+++ b/nativeauthenticator/nativeauthenticator.py
@@ -41,6 +41,11 @@ class NativeAuthenticator(Authenticator):
         help=("Configures the number of seconds a user has to wait "
               "after being blocked. Default is 600.")
     )
+    enable_signup = Bool(
+        config=True,
+        default_value=True,
+        help=("Allows every user to registry a new account")
+    )
     open_signup = Bool(
         config=True,
         default_value=False,
@@ -175,6 +180,9 @@ class NativeAuthenticator(Authenticator):
 
         if not self.is_password_strong(pw) or \
            not self.validate_username(username):
+            return
+
+        if not self.enable_signup:
             return
 
         encoded_pw = bcrypt.hashpw(pw.encode(), bcrypt.gensalt())

--- a/nativeauthenticator/templates/native-login.html
+++ b/nativeauthenticator/templates/native-login.html
@@ -52,9 +52,11 @@ document.addEventListener('DOMContentLoaded', function() {
             <input id="2fa_input" type="text" autocapitalize="off" autocorrect="off" class="form-control" name="2fa" tabindex="1" autofocus="autofocus" placeholder="If you don't have 2FA, leave empty" />
             {% endif %}
             <input type="submit" id="login_submit" class='btn btn-jupyter' value='Sign In' tabindex="3" />
+            {% if enable_signup %}
             <div style="padding-top: 25px;">
                 <p>Don't have an user? <a href="{{ base_url }}signup">Signup!</a></p>
             </div>
+            {% endif %}
         </div>
     </form>
 </div>

--- a/nativeauthenticator/tests/test_authenticator.py
+++ b/nativeauthenticator/tests/test_authenticator.py
@@ -70,6 +70,24 @@ async def test_create_user_with_strong_passwords(password, min_len, expected,
     assert bool(user) == expected
 
 
+@pytest.mark.parametrize("enable_signup,expected_success", [
+    (True, True),
+    (False, False),
+])
+async def test_create_user_disable(enable_signup, expected_success,
+                                   tmpcwd, app):
+    '''Test method get_or_create_user not create user if signup is disabled'''
+    auth = NativeAuthenticator(db=app.db)
+    auth.enable_signup = enable_signup
+
+    user = auth.get_or_create_user('johnsnow', 'password')
+
+    if expected_success:
+        assert user.username == 'johnsnow'
+    else:
+        assert not user
+
+
 @pytest.mark.parametrize("username,password,authorized,expected", [
     ("name", '123', False, False),
     ("johnsnow", '123', True, False),


### PR DESCRIPTION
I find that NativeAuthenticator can only turn off automatic authorization but cannot prevent users registering, so I submit this pr.