### PR TITLE
Signup error

### DIFF
--- a/nativeauthenticator/handlers.py
+++ b/nativeauthenticator/handlers.py
@@ -54,7 +54,7 @@ class SignUpHandler(LocalBase):
                         "username is already in use. Please try again "
                         "with a different username.")
         else:
-			# Error if user creation was not successful.
+            # Error if user creation was not successful.
             if not user:
                 alert = 'alert-danger'
                 pw_len = self.authenticator.minimum_password_length
@@ -66,8 +66,8 @@ class SignUpHandler(LocalBase):
                     message = ("Something went wrong. Be sure your password "
                                " doesn't have spaces or commas and is not too "
                                "common.")
-            
-            # If user creation went through and open-signup is enabled, success.                 
+
+            # If user creation went through and open-signup is enabled, success.
             elif self.authenticator.open_signup:
                 alert = 'alert-success'
                 message = ('The signup was successful. You can now go to '

--- a/nativeauthenticator/handlers.py
+++ b/nativeauthenticator/handlers.py
@@ -43,33 +43,35 @@ class SignUpHandler(LocalBase):
         )
         self.finish(html)
 
-    def get_result_message(self, user, username):
+    def get_result_message(self, user, taken):
         alert = 'alert-info'
-        message = 'Your information have been sent to the admin'
+        message = 'Your information has been sent to the admin'
 
-        if self.authenticator.open_signup:
-            alert = 'alert-success'
-            message = ('The signup was successful. You can now go to '
-                       'home page and log in the system')
-        if not user:
+        # Always error if username is taken.
+        if taken:
             alert = 'alert-danger'
-            pw_len = self.authenticator.minimum_password_length
-            taken = self.authenticator.user_exists(username)
-
-            if pw_len:
-                message = ("Something went wrong. Be sure your password has "
-                           "at least {} characters, doesn't have spaces or "
-                           "commas and is not too common.").format(pw_len)
-
-            elif taken:
-                message = ("Something went wrong. It appears that this "
-                           "username is already in use. Please try again "
-                           "with a different username.")
-
-            else:
-                message = ("Something went wrong. Be sure your password "
-                           " doesn't have spaces or commas and is not too "
-                           "common.")
+            message = ("Something went wrong. It appears that this "
+                        "username is already in use. Please try again "
+                        "with a different username.")
+        else:
+			# Error if user creation was not successful.
+            if not user:
+                alert = 'alert-danger'
+                pw_len = self.authenticator.minimum_password_length
+                if pw_len:
+                    message = ("Something went wrong. Be sure your password has "
+                               "at least {} characters, doesn't have spaces or "
+                               "commas and is not too common.").format(pw_len)
+                else:
+                    message = ("Something went wrong. Be sure your password "
+                               " doesn't have spaces or commas and is not too "
+                               "common.")
+            
+            # If user creation went through and open-signup is enabled, success.                 
+            elif self.authenticator.open_signup:
+                alert = 'alert-success'
+                message = ('The signup was successful. You can now go to '
+                            'home page and log in the system')
 
         return alert, message
 
@@ -83,10 +85,10 @@ class SignUpHandler(LocalBase):
             'email': self.get_body_argument('email', '', strip=False),
             'has_2fa': bool(self.get_body_argument('2fa', '', strip=False)),
         }
+        taken = self.authenticator.user_exists(user_info['username'])
         user = self.authenticator.create_user(**user_info)
-        name = self.authenticator.user_exists(user_info['username'])
 
-        alert, message = self.get_result_message(user, name)
+        alert, message = self.get_result_message(user, taken)
 
         otp_secret, user_2fa = '', ''
         if user:

--- a/nativeauthenticator/handlers.py
+++ b/nativeauthenticator/handlers.py
@@ -44,34 +44,35 @@ class SignUpHandler(LocalBase):
         self.finish(html)
 
     def get_result_message(self, user, taken):
-        alert = 'alert-info'
+        alert   = 'alert-info'
         message = 'Your information has been sent to the admin'
 
         # Always error if username is taken.
         if taken:
             alert = 'alert-danger'
             message = ("Something went wrong. It appears that this "
-                        "username is already in use. Please try again "
-                        "with a different username.")
+                       "username is already in use. Please try again "
+                       "with a different username.")
         else:
             # Error if user creation was not successful.
             if not user:
                 alert = 'alert-danger'
                 pw_len = self.authenticator.minimum_password_length
                 if pw_len:
-                    message = ("Something went wrong. Be sure your password has "
-                               "at least {} characters, doesn't have spaces or "
-                               "commas and is not too common.").format(pw_len)
+                    message = ("Something went wrong. Be sure your "
+                               "password has at least {} characters, doesn't "
+                               "have spaces or commas and is not too "
+                               "common.").format(pw_len)
                 else:
                     message = ("Something went wrong. Be sure your password "
-                               " doesn't have spaces or commas and is not too "
+                               "doesn't have spaces or commas and is not too "
                                "common.")
 
-            # If user creation went through and open-signup is enabled, success.
+            # If user creation went through & open-signup is enabled, success.
             elif self.authenticator.open_signup:
                 alert = 'alert-success'
                 message = ('The signup was successful. You can now go to '
-                            'home page and log in the system')
+                           'home page and log in the system')
 
         return alert, message
 

--- a/nativeauthenticator/handlers.py
+++ b/nativeauthenticator/handlers.py
@@ -44,7 +44,7 @@ class SignUpHandler(LocalBase):
         self.finish(html)
 
     def get_result_message(self, user, taken):
-        alert   = 'alert-info'
+        alert = 'alert-info'
         message = 'Your information has been sent to the admin'
 
         # Always error if username is taken.

--- a/nativeauthenticator/templates/native-login.html
+++ b/nativeauthenticator/templates/native-login.html
@@ -54,7 +54,7 @@ document.addEventListener('DOMContentLoaded', function() {
             <input type="submit" id="login_submit" class='btn btn-jupyter' value='Sign In' tabindex="3" />
             {% if enable_signup %}
             <div style="padding-top: 25px;">
-                <p>Don't have an user? <a href="{{ base_url }}signup">Signup!</a></p>
+                <p>Don't have an account? <a href="{{ base_url }}signup">Signup!</a></p>
             </div>
             {% endif %}
         </div>

--- a/nativeauthenticator/templates/signup.html
+++ b/nativeauthenticator/templates/signup.html
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', function() {
             {% endif %}
             <input type="submit" id="signup_submit" class='btn btn-jupyter' value='Create User' tabindex="3" />
             <div style="padding-top: 25px;">
-                Already have an user? <a href="{{ base_url }}login">Login!</a>
+                Already have an account? <a href="{{ base_url }}login">Login!</a>
             </div>
             {% if alert %}
             <div class="alert {{alert}}" style="margin-top: 15px;" role="alert">


### PR DESCRIPTION
This is basically a follow-up PR to #102, which introduced a bug that now leads to 500 errors (instead of sensible error messages) when signing up with a taken username. This PR removes this bug.

There are also a few minor improvements that I found along the way. These can be factored out if necessary.

- If the chosen username is taken, the software now also errors, even if during open signup.
- Corrected typos and grammar in a few places.