### PR TITLE
ci: rely on pre-commit.ci & run tests only if needed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,25 +9,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  flake8:
-    name: Run flake8
-    runs-on: ubuntu-20.04
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.9"
-
-      - name: Install Python dependencies
-        run: |
-          pip install --no-cache-dir -r dev-requirements.txt
-          pip install .
-
-      - name: Run tests
-        run: |
-          flake8
-
   pytest:
     name: Run pytests
     runs-on: ubuntu-20.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,13 +5,29 @@ name: Test
 
 on:
   pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - "**.rst"
+      - ".github/workflows/*"
+      - "!.github/workflows/test.yaml"
   push:
+    paths-ignore:
+      - "docs/**"
+      - "**.md"
+      - "**.rst"
+      - ".github/workflows/*"
+      - "!.github/workflows/test.yaml"
+    branches-ignore:
+      - "dependabot/**"
+      - "pre-commit-ci-update-config"
   workflow_dispatch:
 
 jobs:
   pytest:
     name: Run pytests
     runs-on: ubuntu-20.04
+
     strategy:
       fail-fast: false
       matrix:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,24 @@ And then installing Native Authenticator from master branch:
 pip install -e .
 ```
 
+### Configure pre-commit
+
+[`pre-commit`](https://pre-commit.com/) is a tool we use to validate code and
+autoformat it. The kind of validation and auto formatting can be inspected via
+the `.pre-commit-config.yaml` file.
+
+As the name implies, `pre-commit` can be configured to run its validation and
+auto formatting just before you make a commit. By configuring it to do so, you
+can avoid having to have a separate commit later that applies auto formatting.
+
+To configure `pre-commit` to run act before you commit, you can run the
+following command from the root of this repository next to the
+`.pre-commit-config.yaml` file.
+
+```shell
+pre-commit install
+```
+
 ### Running your local project
 
 For developing the Native Authenticator, you can start a JupyterHub server using `dev-jupyterhub_config.py`.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,5 +3,6 @@ codecov
 flake8
 notebook>=6.4.1
 onetimepass
+pre-commit
 pytest >= 3.7
 pytest-asyncio


### PR DESCRIPTION
Now with a .pre-commit-config.yaml and changes made so that the pre-commit checks pass in #173 and #174, we can adopt the service https://pre-commit.ci to help us run these tests with very high speed together with automation to apply auto formatting for those that hasn't installed and let pre-commit run before creating a PR.

The use of pre-commit.ci has been considered in https://github.com/jupyterhub/team-compass/issues/379. I've found the service to be really helpful so far, and there seems to be some tentative agreement towards that.