### PR TITLE
chore: use async instead of gen.coroutine

### DIFF
--- a/nativeauthenticator/nativeauthenticator.py
+++ b/nativeauthenticator/nativeauthenticator.py
@@ -11,7 +11,6 @@ from pathlib import Path
 import bcrypt
 from jupyterhub.auth import Authenticator
 from sqlalchemy import inspect
-from tornado import gen
 from tornado import web
 from traitlets import Bool
 from traitlets import Dict
@@ -231,8 +230,7 @@ class NativeAuthenticator(Authenticator):
         if self.login_attempts.get(username):
             self.login_attempts.pop(username)
 
-    @gen.coroutine
-    def authenticate(self, handler, data):
+    async def authenticate(self, handler, data):
         username = self.normalize_username(data["username"])
         password = data["password"]
 


### PR DESCRIPTION
This project has already transitioned away from gen.coroutine as we could after requiring Python 3.6, but I found one function that had the outdated syntax still.

Note that Python 3.6 is required by JupyterHub 1.3.0, and we require JupyterHub 1.3.0+: https://github.com/jupyterhub/jupyterhub/blob/1.3.0/setup.py#L19-L23