### PR TITLE
docs: fix c.JupyterHub.template_paths

### DIFF
--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -34,7 +34,7 @@ Lastly, you need to add the following to the configuration file as well:
 
 ```python
 import os, nativeauthenticator
-c.JupyterHub.template_paths = [f"{os.path.dirname(nativeauthenticator.__file__}/templates/"]
+c.JupyterHub.template_paths = [f"{os.path.dirname(nativeauthenticator.__file__)}/templates/"]
 ```
 
 Now you can run JupyterHub using the updated configuration file and start using JupyterHub with NativeAuthenticator:


### PR DESCRIPTION
I noticed that line 37 of `quickstart.md` is incorrect python code, so I created this pull request.

before

```python
c.JupyterHub.template_paths = [f"{os.path.dirname(nativeauthenticator.__file__}/templates/"]
```

after
```python
c.JupyterHub.template_paths = [f"{os.path.dirname(nativeauthenticator.__file__)}/templates/"]
```
