### PR TITLE
docs: fix c.JupyterHub.template_paths

### DIFF
--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -34,7 +34,7 @@ Lastly, you need to add the following to the configuration file as well:
 
 ```python
 import os, nativeauthenticator
-c.JupyterHub.template_paths = [f"{os.path.dirname(nativeauthenticator.__file__}/templates/"]
+c.JupyterHub.template_paths = [f"{os.path.dirname(nativeauthenticator.__file__)}/templates/"]
 ```
 
 Now you can run JupyterHub using the updated configuration file and start using JupyterHub with NativeAuthenticator:


### PR DESCRIPTION
Line 37 of `docs/source/quickstart.md` is incorrect python code. `)` is needed.

before

```python
c.JupyterHub.template_paths = [f"{os.path.dirname(nativeauthenticator.__file__}/templates/"]
```

after
```python
c.JupyterHub.template_paths = [f"{os.path.dirname(nativeauthenticator.__file__)}/templates/"]
```