### PR TITLE
Correct login procedure for admins

### DIFF
--- a/nativeauthenticator/nativeauthenticator.py
+++ b/nativeauthenticator/nativeauthenticator.py
@@ -311,7 +311,10 @@ class NativeAuthenticator(Authenticator):
         infos = {"username": username, "password": encoded_password}
         infos.update(kwargs)
 
-        if self.open_signup or username in self.get_authed_users():
+        # Pre-authorized users (admins, or any users during open signup)
+        pre_authorized = self.open_signup or username in self.get_authed_users()
+
+        if pre_authorized:
             infos.update({"is_authorized": True})
 
         try:
@@ -319,7 +322,8 @@ class NativeAuthenticator(Authenticator):
         except AssertionError:
             return
 
-        if self.allow_self_approval_for:
+        # Don't send authorization emails to pre-authorized users.
+        if self.allow_self_approval_for and not pre_authorized:
             match = re.match(self.allow_self_approval_for, user_info.email)
             if match:
                 url = self.generate_approval_url(username)


### PR DESCRIPTION
Closes #193. Admins that sign up on the system now _don't_ get authorization emails if that feature is enabled. They also now get a "Signup successful, you can log in now" message instead of the (slightly misleading) "Your data has been sent to the admin" now.

And while I was in there, I removed the unnecessary default value for `assume_user_is_human` in `get_result_message` and re-ordered the arguments to place them in the order they are being checked.