### PR TITLE
Add slash restriction to username validation

### DIFF
--- a/nativeauthenticator/handlers.py
+++ b/nativeauthenticator/handlers.py
@@ -100,7 +100,7 @@ class SignUpHandler(LocalBase):
             if minimum_password_length > 0:
                 message = (
                     "Something went wrong!\nBe sure your username "
-                    "does not contain spaces or commas, your "
+                    "does not contain spaces, commas or slashes, your "
                     f"password has at least {minimum_password_length} "
                     "characters and is not too common."
                 )

--- a/nativeauthenticator/handlers.py
+++ b/nativeauthenticator/handlers.py
@@ -108,7 +108,7 @@ class SignUpHandler(LocalBase):
             else:
                 message = (
                     "Something went wrong!\nBe sure your username "
-                    "does not contain spaces or commas and your "
+                    "does not contain spaces, commas or slashes and your "
                     "password is not too common."
                 )
         # If user creation went through & open-signup is enabled, success.

--- a/nativeauthenticator/nativeauthenticator.py
+++ b/nativeauthenticator/nativeauthenticator.py
@@ -391,7 +391,7 @@ class NativeAuthenticator(Authenticator):
         return True
 
     def validate_username(self, username):
-        invalid_chars = [",", " "]
+        invalid_chars = [",", " ", "/"]
         if any((char in username) for char in invalid_chars):
             return False
         return super().validate_username(username)


### PR DESCRIPTION
Documentation said that spaces, commas and slasher weren't allowed but only the restriction of commas and spaces was enforced.