### PR TITLE
feat: use email as username

### DIFF
--- a/dev-jupyterhub_config.py
+++ b/dev-jupyterhub_config.py
@@ -26,6 +26,8 @@ c.NativeAuthenticator.seconds_before_next_try = 600
 c.NativeAuthenticator.enable_signup = True
 c.NativeAuthenticator.open_signup = False
 c.NativeAuthenticator.ask_email_on_signup = True
+c.NativeAuthenticator.use_email_as_username = True
+c.NativeAuthenticator.open_signup = True
 
 c.NativeAuthenticator.allow_2fa = True
 

--- a/docs/source/options.md
+++ b/docs/source/options.md
@@ -65,6 +65,17 @@ For now, the only extra information you can ask is email. To do so, you can add 
 c.NativeAuthenticator.ask_email_on_signup = True
 ```
 
+### Use email as username
+
+This option basically uses the email as username which prevents users from having to provide an username on the signup form
+
+```python
+c.NativeAuthenticator.use_email_as_username = True
+```
+
+If you are using DockerSpawner please notice that this have a direct impact on the container names since it uses the username to name the container.
+Also, if you are using dockerspawner < 12.0.0 you may face some issues due to a miss alginment with some changes done by the Docker team
+
 ## Use reCaptcha to prevent scripted SignUp attacks
 
 Since by default, anybody can sign up to the system, you may want to use the lightweight

--- a/nativeauthenticator/handlers.py
+++ b/nativeauthenticator/handlers.py
@@ -59,6 +59,7 @@ class SignUpHandler(LocalBase):
         html = await self.render_template(
             "signup.html",
             ask_email=self.authenticator.ask_email_on_signup,
+            use_email_as_username=self.authenticator.use_email_as_username,
             two_factor_auth=self.authenticator.allow_2fa,
             recaptcha_key=self.authenticator.recaptcha_key,
             tos=self.authenticator.tos,
@@ -169,11 +170,14 @@ class SignUpHandler(LocalBase):
 
         if assume_user_is_human:
             user_info = {
-                "username": self.get_body_argument("username", strip=False),
+                "username": self.get_body_argument("username", "", strip=False),
                 "password": self.get_body_argument("signup_password", strip=False),
                 "email": self.get_body_argument("email", "", strip=False),
                 "has_2fa": bool(self.get_body_argument("2fa", "", strip=False)),
             }
+            if self.authenticator.use_email_as_username:
+                user_info["username"] = user_info["email"]
+
             username_already_taken = self.authenticator.user_exists(
                 user_info["username"]
             )
@@ -207,6 +211,7 @@ class SignUpHandler(LocalBase):
         html = await self.render_template(
             "signup.html",
             ask_email=self.authenticator.ask_email_on_signup,
+            use_email_as_username=self.authenticator.use_email_as_username,
             result_message=message,
             alert=alert,
             two_factor_auth=self.authenticator.allow_2fa,
@@ -466,6 +471,7 @@ class LoginHandler(LoginHandler, LocalBase):
             "native-login.html",
             next=url_escape(self.get_argument("next", default="")),
             username=username,
+            use_email_as_username=self.authenticator.use_email_as_username,
             login_error=login_error,
             custom_html=self.authenticator.custom_html,
             login_url=self.settings["login_url"],

--- a/nativeauthenticator/nativeauthenticator.py
+++ b/nativeauthenticator/nativeauthenticator.py
@@ -149,6 +149,11 @@ class NativeAuthenticator(Authenticator):
     )
 
     ask_email_on_signup = Bool(False, config=True, help="Asks for email on signup")
+    use_email_as_username = Bool(
+        False,
+        config=True,
+        help="Use email as username. Note that this requires ask_email_on_signup to be True",
+    )
 
     import_from_firstuse = Bool(
         False, config=True, help="Import users from FirstUse Authenticator database"
@@ -181,6 +186,7 @@ class NativeAuthenticator(Authenticator):
             self.add_data_from_firstuse()
 
         self.setup_self_approval()
+        self.setup_use_email_as_username()
 
     def setup_self_approval(self):
         if self.allow_self_approval_for:
@@ -192,6 +198,10 @@ class NativeAuthenticator(Authenticator):
                     "Secret_key must be a random string of "
                     "len > 8 when using self_approval"
                 )
+
+    def setup_use_email_as_username(self):
+        if self.use_email_as_username:
+            self.ask_email_on_signup = True
 
     def add_new_table(self):
         inspector = inspect(self.db.bind)

--- a/nativeauthenticator/templates/native-login.html
+++ b/nativeauthenticator/templates/native-login.html
@@ -49,7 +49,12 @@
             </p>
             {% endif %}
 
+            {%  if use_email_as_username %}
+            <label for="username_input">Email:</label>
+            {% else %}
             <label for="username_input">Username:</label>
+            {% endif %}
+
             <input id="username_input" type="text" name="username" val="{{username}}" autocapitalize="off" autocorrect="off" class="form-control" autofocus="autofocus" required />
             <p></p>
 

--- a/nativeauthenticator/templates/signup.html
+++ b/nativeauthenticator/templates/signup.html
@@ -72,9 +72,11 @@
             </div>
             {% endif %}
 
+            {% if not use_email_as_username %}
             <label for="username_input">Username:</label>
             <input id="username_input" type="text" name="username" val="{{username}}" autocapitalize="off" autocorrect="off" class="form-control" autofocus="autofocus" required />
             <p></p>
+            {% endif %}
 
             {% if ask_email %}
             <label for="email_input">Email:</label>


### PR DESCRIPTION
Hi everyone,

I would like to propose a feature which in my oppinion improves the overall UX. The idea is to basically use the email as username so that would allow us to remove one field from the signup page. The idea came from a real use case for a project that I am currently working on at Anaconda.

I would love to hear oppinions and feedbacks about this approach and also ideas on how to improve the implementation, that is the very first time that I am contributing to this project (which by the way is awesome, thanks!)

