### PR TITLE
ci: add dependabot bumping of github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# dependabot.yml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Notes:
+# - Status and logs from dependabot are provided at
+#   https://github.com/jupyterhub/nativeauthenticator/network/updates.
+# - YAML anchors are not supported here or in GitHub Workflows.
+#
+version: 2
+updates:
+  # Maintain dependencies in our GitHub Workflows
+  - package-ecosystem: github-actions
+    directory: "/" # This should be / rather than .github/workflows
+    schedule:
+      interval: weekly
+      time: "05:00"
+      timezone: "Etc/UTC"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,10 +14,10 @@ jobs:
     name: Publish to PyPI
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
 
       - name: Install build package
         run: |
@@ -31,7 +31,7 @@ jobs:
           ls -alh dist
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.4.1
+        uses: pypa/gh-action-pypi-publish@v1.5.1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,8 +44,8 @@ jobs:
             jupyterhub-version: "2.*"
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "${{ matrix.python-version }}"
 


### PR DESCRIPTION
I'll go for a quick self-merge on this and creating another PR that may would have a merge conflict with this to test against jupyterhub 3 on python 3.11