### PR TITLE
ci: add tests against jupyterhub 3 and python 3.11

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,8 @@ jobs:
             jupyterhub-version: "2.*"
           - python-version: "3.10"
             jupyterhub-version: "2.*"
+          - python-version: "3.11.0-rc.1"
+            jupyterhub-version: "3.*"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Wieee, tests pass against jupyterhub 3 and python 3.11's release candidate as well!