### PR TITLE
ci: add RELEASE.md and tbump.toml

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,42 @@
+# How to make a release
+
+`jupyterhub-nativeauthenticator` is a package [available on
+PyPI](https://pypi.org/project/jupyterhub-nativeauthenticator/). These are
+instructions on how to make a release on PyPI. The PyPI release is done
+automatically by CI when a tag is pushed.
+
+For you to follow along according to these instructions, you need:
+
+- To have push rights to the [jupyterhub GitHub repository](https://github.com/jupyterhub/nativeauthenticator).
+- To have [`tbump`](https://pypi.org/project/tbump) installed.
+
+## Steps to make a release
+
+1. Make sure `CHANGELOG.md` is up-to-date using [github-activity][] ahead of
+   time in a dedicated PR.
+
+1. Checkout main and make sure it is up to date.
+
+   ```shell
+   ORIGIN=${ORIGIN:-origin} # set to the canonical remote, e.g. 'upstream' if 'origin' is not the official repo
+   git checkout main
+   git fetch $ORIGIN main
+   git reset --hard $ORIGIN/main
+   ```
+
+1. Update the version with `tbump`. You can see what will happen without making
+   any changes with `tbump --dry-run ${VERSION}`.
+
+   ```shell
+   tbump ${VERSION}
+   ```
+
+   This will tag and publish a release, which will be finished on CI.
+
+1. Reset the version back to dev, e.g. `2.1.0.dev` after releasing `2.0.0`
+
+   ```shell
+   tbump --no-tag ${NEXT_VERSION}.dev
+   ```
+
+[github-activity]: https://github.com/executablebooks/github-activity

--- a/tbump.toml
+++ b/tbump.toml
@@ -1,0 +1,30 @@
+# tbump is a tool to update version fields that we use
+# to update version in setup.py as documented
+# in RELEASE.md
+#
+# Config reference: https://github.com/your-tools/tbump#readme
+#
+[version]
+current = "1.0.5"
+
+regex = '''
+  (?P<major>\d+)
+  \.
+  (?P<minor>\d+)
+  \.
+  (?P<patch>\d+)
+  (?P<pre>((a|b|rc)\d+)|)
+  \.?
+  (?P<dev>(?<=\.)dev\d*|)
+  '''
+
+[git]
+message_template = "Bump to {new_version}"
+tag_template = "{new_version}"
+
+# For each file to patch, add a [[file]] config
+# section containing the path of the file, relative to the
+# tbump.toml location.
+[[file]]
+src = "setup.py"
+search = 'version="{current_version}"'


### PR DESCRIPTION
I added a typical RELEASE.md file as most jupyterhub projects has to help anyone make a release in a systematic way. `tbump` is a tool that helps us automate that a bit further as well, also adopted in various jupyterhub repositories.