### PR TITLE
Add changelog for 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,96 @@
-## [1.0.0] - 2021-10-18
+# Changelog
+
+<!--
+The changelog should be updated using the tool `github-activity --heading-level=3`.
+
+To install and configure it, see https://github.com/executablebooks/github-activity#readme.
+-->
+
+## 1.1
+
+### 1.1.0 - 2022-09-09
+
+([full changelog](https://github.com/jupyterhub/nativeauthenticator/compare/1.0.5...1.1.0))
+
+#### Enhancements made
+
+- Ask for new passwords twice, ask for current password on change [#180](https://github.com/jupyterhub/nativeauthenticator/pull/180) ([@lambdaTotoro](https://github.com/lambdaTotoro))
+
+#### Bugs fixed
+
+- Add slash restriction to username validation [#197](https://github.com/jupyterhub/nativeauthenticator/pull/197) ([@marc-marcos](https://github.com/marc-marcos))
+- Correct login procedure for admins [#195](https://github.com/jupyterhub/nativeauthenticator/pull/195) ([@lambdaTotoro](https://github.com/lambdaTotoro))
+- Enforce password criteria on password change [#169](https://github.com/jupyterhub/nativeauthenticator/pull/169) ([@lambdaTotoro](https://github.com/lambdaTotoro))
+- Systematic refresh of templates [#162](https://github.com/jupyterhub/nativeauthenticator/pull/162) ([@consideRatio](https://github.com/consideRatio))
+
+#### Maintenance and upkeep improvements
+
+- document and refactor the handlers [#183](https://github.com/jupyterhub/nativeauthenticator/pull/183) ([@lambdaTotoro](https://github.com/lambdaTotoro))
+- chore: use async instead of gen.coroutine [#178](https://github.com/jupyterhub/nativeauthenticator/pull/178) ([@consideRatio](https://github.com/consideRatio))
+- pre-commit: apply black formatting [#174](https://github.com/jupyterhub/nativeauthenticator/pull/174) ([@consideRatio](https://github.com/consideRatio))
+- Smaller tweaks from pre-commit autoformatting hooks [#173](https://github.com/jupyterhub/nativeauthenticator/pull/173) ([@consideRatio](https://github.com/consideRatio))
+- Support JupyterHub 2's fine grained RBAC permissions, and test against Py3.10 and JH2 [#160](https://github.com/jupyterhub/nativeauthenticator/pull/160) ([@consideRatio](https://github.com/consideRatio))
+
+#### Documentation improvements
+
+- update documentation screenshots [#194](https://github.com/jupyterhub/nativeauthenticator/pull/194) ([@lambdaTotoro](https://github.com/lambdaTotoro))
+- docs: fix c.JupyterHub.template_paths [#192](https://github.com/jupyterhub/nativeauthenticator/pull/192) ([@yapatta](https://github.com/yapatta))
+- docs: c.NativeAuthenticator instead of c.Authenticator [#188](https://github.com/jupyterhub/nativeauthenticator/pull/188) ([@consideRatio](https://github.com/consideRatio))
+- docs: update from rST to MyST and to common theme [#187](https://github.com/jupyterhub/nativeauthenticator/pull/187) ([@consideRatio](https://github.com/consideRatio))
+- document and refactor the handlers [#183](https://github.com/jupyterhub/nativeauthenticator/pull/183) ([@lambdaTotoro](https://github.com/lambdaTotoro))
+- docs: add inline documentation to orm.py [#179](https://github.com/jupyterhub/nativeauthenticator/pull/179) ([@consideRatio](https://github.com/consideRatio))
+- Update CONTRIBUTING.md [#161](https://github.com/jupyterhub/nativeauthenticator/pull/161) ([@consideRatio](https://github.com/consideRatio))
+
+#### Continuous integration improvements
+
+- ci: add RELEASE.md and tbump.toml [#217](https://github.com/jupyterhub/nativeauthenticator/pull/217) ([@consideRatio](https://github.com/consideRatio))
+- ci: add tests against jupyterhub 3 and python 3.11 [#216](https://github.com/jupyterhub/nativeauthenticator/pull/216) ([@consideRatio](https://github.com/consideRatio))
+- ci: add dependabot bumping of github actions [#215](https://github.com/jupyterhub/nativeauthenticator/pull/215) ([@consideRatio](https://github.com/consideRatio))
+- ci: rely on pre-commit.ci & run tests only if needed [#175](https://github.com/jupyterhub/nativeauthenticator/pull/175) ([@consideRatio](https://github.com/consideRatio))
+
+#### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterhub/nativeauthenticator/graphs/contributors?from=2021-10-19&to=2022-09-09&type=c))
+
+[@consideRatio](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3AconsideRatio+updated%3A2021-10-19..2022-09-09&type=Issues) | [@harshu1470](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Aharshu1470+updated%3A2021-10-19..2022-09-09&type=Issues) | [@lambdaTotoro](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3AlambdaTotoro+updated%3A2021-10-19..2022-09-09&type=Issues) | [@leportella](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Aleportella+updated%3A2021-10-19..2022-09-09&type=Issues) | [@manics](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Amanics+updated%3A2021-10-19..2022-09-09&type=Issues) | [@marc-marcos](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Amarc-marcos+updated%3A2021-10-19..2022-09-09&type=Issues) | [@yapatta](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Ayapatta+updated%3A2021-10-19..2022-09-09&type=Issues)
+
+## 1.0
+
+### 1.0.5 - 2021-10-19
+
+This releases resolves an incorrect Python module structure that lead to a failing import when installing from a built wheel.
+
+([full changelog](https://github.com/jupyterhub/nativeauthenticator/compare/1.0.4...1.0.5))
+
+### 1.0.4 - 2021-10-19
+
+This release includes a bugfix related to an import statement.
+
+([full changelog](https://github.com/jupyterhub/nativeauthenticator/compare/1.0.3...1.0.4))
+
+### 1.0.3 - 2021-10-19
+
+This release includes a bugfix of an import statement.
+
+([full changelog](https://github.com/jupyterhub/nativeauthenticator/compare/1.0.2...1.0.3))
+
+### 1.0.2 - 2021-10-19
+
+This release includes documentation updates and an attempted bugfix of an import statement.
+
+([full changelog](https://github.com/jupyterhub/nativeauthenticator/compare/1.0.1...1.0.2))
+
+### 1.0.1 - 2021-10-18
+
+A small release hiccup resolved.
+
+([full changelog](https://github.com/jupyterhub/nativeauthenticator/compare/1.0.0...1.0.1))
+
+### 1.0.0 - 2021-10-18
 
 As tracked by #149 and especially since the incorporation of multiple substantial and new features, we are now happy to call this version 1.0.0.
 
-### What's Changed
+#### What's Changed
 
 Here are the main contributions in this release:
 
@@ -27,20 +115,22 @@ Special shoutout also goes to @davidedelvento who contributed a lot of work in t
 
 **Full Changelog**: https://github.com/jupyterhub/nativeauthenticator/compare/0.0.7...1.0.0
 
-## [0.0.7] - 2021-01-14
+## 0.0
 
-### Merged PRs
+### 0.0.7 - 2021-01-14
+
+#### Merged PRs
 
 - fix: we now need to await render_template method [#129](https://github.com/jupyterhub/nativeauthenticator/pull/129) ([@djangoliv](https://github.com/djangoliv))
 - Bump notebook from 5.7.8 to 6.1.5 [#125](https://github.com/jupyterhub/nativeauthenticator/pull/125) ([@dependabot](https://github.com/dependabot))
 
-### Contributors to this release
+#### Contributors to this release
 
 [@dependabot](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Adependabot+updated%3A2020-11-12..2021-01-11&type=Issues) | [@djangoliv](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Adjangoliv+updated%3A2020-11-12..2021-01-11&type=Issues) | [@lambdaTotoro](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3AlambdaTotoro+updated%3A2020-11-12..2021-01-11&type=Issues)
 
-## [0.0.6] - 2020-11-14
+### 0.0.6 - 2020-11-14
 
-### Merged PRs
+#### Merged PRs
 
 - Discard from authorize [#121](https://github.com/jupyterhub/nativeauthenticator/pull/121) ([@lambdaTotoro](https://github.com/lambdaTotoro))
 - Allowed users [#120](https://github.com/jupyterhub/nativeauthenticator/pull/120) ([@lambdaTotoro](https://github.com/lambdaTotoro))
@@ -55,13 +145,13 @@ Special shoutout also goes to @davidedelvento who contributed a lot of work in t
 - add changelog [#101](https://github.com/jupyterhub/nativeauthenticator/pull/101) ([@leportella](https://github.com/leportella))
 - fix orm for support mysql [#57](https://github.com/jupyterhub/nativeauthenticator/pull/57) ([@00Kai0](https://github.com/00Kai0))
 
-### Contributors to this release
+#### Contributors to this release
 
 [@00Kai0](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3A00Kai0+updated%3A2020-02-20..2020-11-12&type=Issues) | [@dependabot](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Adependabot+updated%3A2020-02-20..2020-11-12&type=Issues) | [@djangoliv](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Adjangoliv+updated%3A2020-02-20..2020-11-12&type=Issues) | [@fbessou](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Afbessou+updated%3A2020-02-20..2020-11-12&type=Issues) | [@lambdaTotoro](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3AlambdaTotoro+updated%3A2020-02-20..2020-11-12&type=Issues) | [@leportella](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Aleportella+updated%3A2020-02-20..2020-11-12&type=Issues) | [@mayswind](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Amayswind+updated%3A2020-02-20..2020-11-12&type=Issues) | [@minrk](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Aminrk+updated%3A2020-02-20..2020-11-12&type=Issues) | [@shreeishitagupta](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Ashreeishitagupta+updated%3A2020-02-20..2020-11-12&type=Issues)
 
-## [0.0.5] - 2020-02-20
+### 0.0.5 - 2020-02-20
 
-### Merged PRs
+#### Merged PRs
 
 - Revert "fix timedelta.seconds misuse" [#100](https://github.com/jupyterhub/nativeauthenticator/pull/100) ([@leportella](https://github.com/leportella))
 - upgrade version to launch at pypi [#99](https://github.com/jupyterhub/nativeauthenticator/pull/99) ([@leportella](https://github.com/leportella))
@@ -80,13 +170,13 @@ Special shoutout also goes to @davidedelvento who contributed a lot of work in t
 - Add importation of db from FirstUse Auth [#67](https://github.com/jupyterhub/nativeauthenticator/pull/67) ([@leportella](https://github.com/leportella))
 - Change setup to version 0.0.4 [#65](https://github.com/jupyterhub/nativeauthenticator/pull/65) ([@leportella](https://github.com/leportella))
 
-### Contributors to this release
+#### Contributors to this release
 
 [@chicocvenancio](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Achicocvenancio+updated%3A2019-02-15..2020-02-20&type=Issues) | [@choldgraf](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Acholdgraf+updated%3A2019-02-15..2020-02-20&type=Issues) | [@consideRatio](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3AconsideRatio+updated%3A2019-02-15..2020-02-20&type=Issues) | [@databasedav](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Adatabasedav+updated%3A2019-02-15..2020-02-20&type=Issues) | [@harshu1470](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Aharshu1470+updated%3A2019-02-15..2020-02-20&type=Issues) | [@hiroki-sawano](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Ahiroki-sawano+updated%3A2019-02-15..2020-02-20&type=Issues) | [@JohnPaton](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3AJohnPaton+updated%3A2019-02-15..2020-02-20&type=Issues) | [@lambdaTotoro](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3AlambdaTotoro+updated%3A2019-02-15..2020-02-20&type=Issues) | [@leportella](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Aleportella+updated%3A2019-02-15..2020-02-20&type=Issues) | [@meownoid](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Ameownoid+updated%3A2019-02-15..2020-02-20&type=Issues) | [@paulbaracch](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Apaulbaracch+updated%3A2019-02-15..2020-02-20&type=Issues) | [@raethlein](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Araethlein+updated%3A2019-02-15..2020-02-20&type=Issues) | [@xrdy511623](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Axrdy511623+updated%3A2019-02-15..2020-02-20&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Ayuvipanda+updated%3A2019-02-15..2020-02-20&type=Issues)
 
-## [0.0.4] - 2019-02-15
+### 0.0.4 - 2019-02-15
 
-### Merged PRs
+#### Merged PRs
 
 - Change image of block attemps workflow [#64](https://github.com/jupyterhub/nativeauthenticator/pull/64) ([@leportella](https://github.com/leportella))
 - add MANIFEST.in to ensure files get packaged [#63](https://github.com/jupyterhub/nativeauthenticator/pull/63) ([@minrk](https://github.com/minrk))
@@ -95,47 +185,47 @@ Special shoutout also goes to @davidedelvento who contributed a lot of work in t
 - fix raise error when email is none [#56](https://github.com/jupyterhub/nativeauthenticator/pull/56) ([@00Kai0](https://github.com/00Kai0))
 - fix password is not bytes in mysql [#55](https://github.com/jupyterhub/nativeauthenticator/pull/55) ([@00Kai0](https://github.com/00Kai0))
 
-### Contributors to this release
+#### Contributors to this release
 
 [@00Kai0](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3A00Kai0+updated%3A2019-02-13..2019-02-15&type=Issues) | [@leportella](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Aleportella+updated%3A2019-02-13..2019-02-15&type=Issues) | [@minrk](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Aminrk+updated%3A2019-02-13..2019-02-15&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Ayuvipanda+updated%3A2019-02-13..2019-02-15&type=Issues)
 
-## [0.0.3] - 2019-02-13
+### 0.0.3 - 2019-02-13
 
-### Merged PRs
+#### Merged PRs
 
 - Change package_data to include_package_data [#60](https://github.com/jupyterhub/nativeauthenticator/pull/60) ([@leportella](https://github.com/leportella))
 - Increase Native Auth version to 0.0.2 [#59](https://github.com/jupyterhub/nativeauthenticator/pull/59) ([@leportella](https://github.com/leportella))
 
-### Contributors to this release
+#### Contributors to this release
 
 [@leportella](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Aleportella+updated%3A2019-02-13..2019-02-13&type=Issues)
 
-### Merged PRs
+#### Merged PRs
 
 - Change package_data to include_package_data [#60](https://github.com/jupyterhub/nativeauthenticator/pull/60) ([@leportella](https://github.com/leportella))
 - Increase Native Auth version to 0.0.2 [#59](https://github.com/jupyterhub/nativeauthenticator/pull/59) ([@leportella](https://github.com/leportella))
 
-### Contributors to this release
+#### Contributors to this release
 
 ([GitHub contributors page for this release](https://github.com/jupyterhub/nativeauthenticator/graphs/contributors?from=2019-02-13&to=2019-02-13&type=c))
 
 [@leportella](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Aleportella+updated%3A2019-02-13..2019-02-13&type=Issues)
 
-## [0.0.2] - 2019-02-13
+### 0.0.2 - 2019-02-13
 
-### Merged PRs
+#### Merged PRs
 
 - Change button from Deauthorize to Unauthorize [#58](https://github.com/jupyterhub/nativeauthenticator/pull/58) ([@leportella](https://github.com/leportella))
 - Add description to README and setup.py [#54](https://github.com/jupyterhub/nativeauthenticator/pull/54) ([@leportella](https://github.com/leportella))
 - Fix data packaging on setup.py [#53](https://github.com/jupyterhub/nativeauthenticator/pull/53) ([@leportella](https://github.com/leportella))
 
-### Contributors to this release
+#### Contributors to this release
 
 [@leportella](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Aleportella+updated%3A2019-02-12..2019-02-13&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Ayuvipanda+updated%3A2019-02-12..2019-02-13&type=Issues)
 
-## [0.0.1] - 2019-02-12
+### 0.0.1 - 2019-02-12
 
-### Merged PRs
+#### Merged PRs
 
 - Improving docs with images [#50](https://github.com/jupyterhub/nativeauthenticator/pull/50) ([@leportella](https://github.com/leportella))
 - Delete user info from admin panel [#49](https://github.com/jupyterhub/nativeauthenticator/pull/49) ([@leportella](https://github.com/leportella))
@@ -167,6 +257,6 @@ Special shoutout also goes to @davidedelvento who contributed a lot of work in t
 - Add minimal tests [#5](https://github.com/jupyterhub/nativeauthenticator/pull/5) ([@leportella](https://github.com/leportella))
 - Add first structure to NativeAuthenticator [#4](https://github.com/jupyterhub/nativeauthenticator/pull/4) ([@leportella](https://github.com/leportella))
 
-### Contributors to this release
+#### Contributors to this release
 
 [@leportella](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Aleportella+updated%3A2018-12-03..2019-02-12&type=Issues) | [@minrk](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Aminrk+updated%3A2018-12-03..2019-02-12&type=Issues) | [@yuvipanda](https://github.com/search?q=repo%3Ajupyterhub%2Fnativeauthenticator+involves%3Ayuvipanda+updated%3A2018-12-03..2019-02-12&type=Issues)


### PR DESCRIPTION
Besides adding an entry for 1.1.0, I'm backfilling some notes for 1.0.1-1.0.5 as well, and adjusts the heading level to align with the typical changelogs in other jupyterhub repositories.

I chatted with @lambdaTotoro on twitter who had some vacation time who agreed I could go for a release, so with the approval of @minrk I'll go for one now.

- Closes #214

---

Note that I sprinted and self merged the following just before this:

- #215
- #216
- #217

I'm expediting this to get it as part of the z2jh 2.0.0 release I'd love to make now today (https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2855)