### PR TITLE
fixes  #219

### DIFF
--- a/nativeauthenticator/nativeauthenticator.py
+++ b/nativeauthenticator/nativeauthenticator.py
@@ -304,9 +304,8 @@ class NativeAuthenticator(Authenticator):
             else:
                 return
 
-        if not from_firstuse:
-            if not self.is_password_strong(password):
-                return
+        if not self.is_password_strong(password):
+            return
 
         if not self.enable_signup:
             return


### PR DESCRIPTION
Fixed an issue when using c.NativeAuthenticator.import_from_firstuse = True:

When importing users from passwords.dbm, the hashed password was processed as if it was a cleartext password, leading the original password to fail and preventing imported users from logging in.

An extra keyword option "from_firstuse" was added to create_user() to handle this special case.

**Note:** With this code, the imported passwords do not get checked for password length or common passwords as currently mentioned in the documentation [here](https://native-authenticator.readthedocs.io/en/latest/options.html#import-users-from-firstuse-authenticator)!
