### PR TITLE
fixes #219

### DIFF
--- a/nativeauthenticator/nativeauthenticator.py
+++ b/nativeauthenticator/nativeauthenticator.py
@@ -304,9 +304,8 @@ class NativeAuthenticator(Authenticator):
             else:
                 return
 
-        if not from_firstuse:
-            if not self.is_password_strong(password):
-                return
+        if not self.is_password_strong(password):
+            return
 
         if not self.enable_signup:
             return


### PR DESCRIPTION
Fixed an issue (#219) when using c.NativeAuthenticator.import_from_firstuse = True:

When importing users from passwords.dbm, the hashed password was processed as if it was a cleartext password, leading the original password to fail and preventing imported users from logging in.

An extra keyword option "from_firstuse" was added to create_user() to handle this special case.

**Note:** I also think that the password safety check fails on weak passwords if they are already in hashed form in the imported database. This pull request might fail the tests (this is my second attempt), but I think it might be a problem with the tests?
Did the FirstUseAuthenticator databases used to be unencrypted?
