### PR TITLE
Register native as an jupyterhub authenticator class

### DIFF
--- a/dev-jupyterhub_config.py
+++ b/dev-jupyterhub_config.py
@@ -3,7 +3,7 @@ import os
 import nativeauthenticator
 
 c.JupyterHub.spawner_class = "simple"
-c.JupyterHub.authenticator_class = "nativeauthenticator.NativeAuthenticator"
+c.JupyterHub.authenticator_class = "native"
 c.Authenticator.admin_users = {"admin"}
 
 # Required configuration of templates location

--- a/docs/source/quickstart.md
+++ b/docs/source/quickstart.md
@@ -27,7 +27,7 @@ jupyterhub --generate-config -f /etc/jupyterhub/jupyterhub_config.py
 Also, change the default authenticator class to NativeAuthenticator:
 
 ```python
-c.JupyterHub.authenticator_class = 'nativeauthenticator.NativeAuthenticator'
+c.JupyterHub.authenticator_class = 'native'
 ```
 
 Lastly, you need to add the following to the configuration file as well:

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,17 @@ setup(
     author_email="leportella@protonmail.com",
     license="3 Clause BSD",
     packages=find_packages(),
+    entry_points={
+        # Thanks to this, user are able to do:
+        #
+        #     c.JupyterHub.authenticator_class = "native"
+        #
+        # ref: https://jupyterhub.readthedocs.io/en/4.0.0/reference/authenticators.html#registering-custom-authenticators-via-entry-points
+        #
+        "jupyterhub.authenticators": [
+            "native = nativeauthenticator:NativeAuthenticator",
+        ],
+    },
     install_requires=[
         "jupyterhub>=1.3",
         "bcrypt",


### PR DESCRIPTION
This makes it possible to do `c.JupyterHub.authenticator_class = "native"`.

Similar PR in tmpauthenticator:
- https://github.com/jupyterhub/tmpauthenticator/pull/38