### PR TITLE
Fix page.html menu bar

### DIFF
--- a/nativeauthenticator/templates/page.html
+++ b/nativeauthenticator/templates/page.html
@@ -2,8 +2,8 @@
 
 {% block nav_bar_left_items %}
     {{ super() }}
-    <li><a href="{{base_url}}change-password">Change Password</a></li>
+    <li class="nav-item"><a class="nav-link" href="{{base_url}}change-password">Change Password</a></li>
     {% if user.admin %}
-        <li><a href="{{base_url}}authorize">Authorize Users</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{base_url}}authorize">Authorize Users</a></li>
     {% endif %}
 {% endblock %}


### PR DESCRIPTION
Fixed page.html template menu bar appearence.
After the fix it appears the correct way:
![immagine](https://github.com/user-attachments/assets/e434fdbb-2398-49fe-9b0f-01918b23355f)
