### PR TITLE
Fix user was added on sign-up even if password didn't match confirmation

### DIFF
--- a/nativeauthenticator/handlers.py
+++ b/nativeauthenticator/handlers.py
@@ -168,7 +168,9 @@ class SignUpHandler(LocalBase):
             user_info = {
                 "username": self.get_body_argument("username", strip=False),
                 "password": self.get_body_argument("signup_password", strip=False),
-		"password_confirmation": self.get_body_argument("signup_password_confirmation", strip=False),
+                "password_confirmation": self.get_body_argument(
+                    "signup_password_confirmation", strip=False
+                ),
                 "email": self.get_body_argument("email", "", strip=False),
                 "has_2fa": bool(self.get_body_argument("2fa", "", strip=False)),
             }

--- a/nativeauthenticator/handlers.py
+++ b/nativeauthenticator/handlers.py
@@ -168,12 +168,14 @@ class SignUpHandler(LocalBase):
             user_info = {
                 "username": self.get_body_argument("username", strip=False),
                 "password": self.get_body_argument("signup_password", strip=False),
+		"password_confirmation": self.get_body_argument("signup_password_confirmation", strip=False),
                 "email": self.get_body_argument("email", "", strip=False),
                 "has_2fa": bool(self.get_body_argument("2fa", "", strip=False)),
             }
             username_already_taken = self.authenticator.user_exists(
                 user_info["username"]
             )
+
             user = self.authenticator.create_user(**user_info)
         else:
             username_already_taken = False

--- a/nativeauthenticator/nativeauthenticator.py
+++ b/nativeauthenticator/nativeauthenticator.py
@@ -291,13 +291,10 @@ class NativeAuthenticator(Authenticator):
     def user_exists(self, username):
         return self.get_user(username) is not None
 
-    def create_user(self, username, password, password_confirmation, **kwargs):
+    def create_user(self, username, password, **kwargs):
         username = self.normalize_username(username)
 
         if self.user_exists(username) or not self.validate_username(username):
-            return
-
-        if not password == password_confirmation:
             return
 
         if not self.is_password_strong(password):
@@ -432,7 +429,7 @@ class NativeAuthenticator(Authenticator):
         with dbm.open(self.firstuse_db_path, "c", 0o600) as db:
             for user in db.keys():
                 password = db[user].decode()
-                new_user = self.create_user(user.decode(), password, password)
+                new_user = self.create_user(user.decode(), password)
                 if not new_user:
                     error = (
                         f"User {user} was not created. Check password "

--- a/nativeauthenticator/nativeauthenticator.py
+++ b/nativeauthenticator/nativeauthenticator.py
@@ -291,10 +291,13 @@ class NativeAuthenticator(Authenticator):
     def user_exists(self, username):
         return self.get_user(username) is not None
 
-    def create_user(self, username, password, **kwargs):
+    def create_user(self, username, password, password_confirmation, **kwargs):
         username = self.normalize_username(username)
 
         if self.user_exists(username) or not self.validate_username(username):
+            return
+
+        if not password == password_confirmation:
             return
 
         if not self.is_password_strong(password):
@@ -429,7 +432,7 @@ class NativeAuthenticator(Authenticator):
         with dbm.open(self.firstuse_db_path, "c", 0o600) as db:
             for user in db.keys():
                 password = db[user].decode()
-                new_user = self.create_user(user.decode(), password)
+                new_user = self.create_user(user.decode(), password, password)
                 if not new_user:
                     error = (
                         f"User {user} was not created. Check password "


### PR DESCRIPTION
In the current version of nativeauthenticator, there is a bug that adds a new user who is signing-up to the database even if the chosen password does not match the confirmation password.
This commit fixes it.