### PR TITLE
Require jupyterhub 4.1.6+ and Python 3.9+

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   build-release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       # id-token=write is required for pypa/gh-action-pypi-publish, and the PyPI
       # project needs to be configured to trust this workflow.
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: install build package
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,26 +23,16 @@ on:
 
 jobs:
   pytest:
-    # FIXME: ubuntu-20.04 comes with py36, but ubuntu-22.04 doesn't, so only
-    #        bump this when we stop testing py36
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.6"
-            pip-install-spec: "jupyterhub==1.3.* sqlalchemy==1.*"
-          - python-version: "3.7"
-            pip-install-spec: "jupyterhub==1.4.* sqlalchemy==1.*"
-          - python-version: "3.8"
-            pip-install-spec: "jupyterhub==1.* sqlalchemy==1.*"
           - python-version: "3.9"
-            pip-install-spec: "jupyterhub==2.* sqlalchemy==1.*"
-          - python-version: "3.10"
-            pip-install-spec: "jupyterhub==3.*"
-          - python-version: "3.11"
             pip-install-spec: "jupyterhub==4.*"
+          - python-version: "3.12"
+            pip-install-spec: "jupyterhub==5.*"
           - python-version: "3.x"
             pip-install-spec: "--pre jupyterhub"
             accept-failure: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - --py36-plus
+          - --py39-plus
 
   # Autoformat: Python code
   - repo: https://github.com/PyCQA/autoflake

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,10 @@ remove-unused-variables = true
 [tool.black]
 skip-string-normalization = true
 target_version = [
-    "py36",
-    "py37",
-    "py38",
     "py39",
     "py310",
     "py311",
+    "py312",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,9 @@ setup(
             "native = nativeauthenticator:NativeAuthenticator",
         ],
     },
+    python_requires=">=3.9",
     install_requires=[
-        "jupyterhub>=1.3",
+        "jupyterhub>=4.1.6",
         "bcrypt",
         "onetimepass",
     ],


### PR DESCRIPTION
- fixes #261

Dropping jupyterhub <4 was agreed between me @manics and @minrk, but requiring Python 3.9 hasn't been discussed.

Python 3.8 reaches end of life and won't get security patches in a month, so I figure we could go for a reduction of what versions we support now to exclude 3.8.