### PR TITLE
Update .flake8 config to match other jupyterhub repos

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,11 +1,16 @@
-[flake8]
-# Adjustments to comply with black autoformatting as described here:
-# https://black.readthedocs.io/en/latest/guides/using_black_with_other_tools.html#flake8
+# flake8 is used for linting Python code setup to automatically run with
+# pre-commit.
 #
-extend-ignore = E203, E501
-max-line-length = 88
+# ref: https://flake8.pycqa.org/en/latest/user/configuration.html
+#
 
-# Project specific adjustments
-#
+[flake8]
+# Ignore style and complexity
+# E: style errors
+# W: style warnings
+# C: complexity
+# D: docstring warnings (unused pydocstyle extension)
+ignore = E, C, W, D
 builtins =
     c
+    get_config


### PR DESCRIPTION
I expected unitialized variables to be caught by flake8, so I looked at this config to verify we didn't ignore more than usual - but we didn't. Not sure why #275 ended up fixing a previously undetected `user_info` not being initialized.