### PR TITLE
docs: fix configuration typo

### DIFF
--- a/dev-jupyterhub_config.py
+++ b/dev-jupyterhub_config.py
@@ -47,5 +47,5 @@ c.NativeAuthenticator.tos = 'I agree to the <a href="your-url" target="_blank">T
 # }
 
 c.NativeAuthenticator.import_from_firstuse = False
-c.NativeAuthenticator.firstuse_dbm_path = "/home/user/passwords.dbm"
+c.NativeAuthenticator.firstuse_db_path = "/home/user/passwords.dbm"
 c.NativeAuthenticator.delete_firstuse_db_after_import = False

--- a/docs/source/options.md
+++ b/docs/source/options.md
@@ -169,7 +169,7 @@ c.NativeAuthenticator.import_from_firstuse = True
 By default, Native Authenticator assumes that the path for the database is the same directory. If that's not the case, you can change the path the file through this variables:
 
 ```python
-c.NativeAuthenticator.firstuse_dbm_path = '/home/user/passwords.dbm'
+c.NativeAuthenticator.firstuse_db_path = '/home/user/passwords.dbm'
 ```
 
 Native Authenticator ensures that usernames are sanitized, so they won't have commas


### PR DESCRIPTION
The configuration below was incorrectly referenced by the docs and a dev config.

https://github.com/jupyterhub/nativeauthenticator/blob/80b99a3b8df665a9feeaa5d7b99980ecba1f18fa/nativeauthenticator/nativeauthenticator.py#L153-L159